### PR TITLE
Моисеев Никита. Лабораторная работа №3

### DIFF
--- a/modules/chuvashov_a_ra_convertor/CMakeLists.txt
+++ b/modules/chuvashov_a_ra_convertor/CMakeLists.txt
@@ -3,6 +3,7 @@ get_filename_component(DIR_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
 set(MODULE      "${DIR_NAME}")
 set(LIBRARY     "lib_${MODULE}")
 set(TESTS       "test_${MODULE}")
+set(APPLICATION "app_${MODULE}")
 
 # Include directory with public headers
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
@@ -10,3 +11,10 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 # Add all submodules
 add_subdirectory(src)
 add_subdirectory(test)
+add_subdirectory(application)
+
+#############################################
+##### Testing
+#############################################
+
+include("CTestTests.txt")

--- a/modules/chuvashov_a_ra_convertor/CTestTests.txt
+++ b/modules/chuvashov_a_ra_convertor/CTestTests.txt
@@ -58,6 +58,15 @@ LABELS "${MODULE}"
 )
 
 add_test(
+    NAME ${prefix}_test_roman_to_arabic_2
+    COMMAND ${APPLICATION} "II"
+)
+set_tests_properties (${prefix}_test_roman_to_arabic_2 PROPERTIES
+    PASS_REGULAR_EXPRESSION "2"
+    LABELS "${MODULE}"
+)
+
+add_test(
 NAME ${prefix}_test_roman_to_arabic_3
 COMMAND ${APPLICATION} "XVI"
 )
@@ -72,6 +81,23 @@ COMMAND ${APPLICATION} "MDCLXVI"
 )
 set_tests_properties (${prefix}_test_roman_to_arabic_4 PROPERTIES
 PASS_REGULAR_EXPRESSION "1666"
+LABELS "${MODULE}"
+)
+add_test(
+    NAME ${prefix}_test_arabic_to_roman_1
+    COMMAND ${APPLICATION} "4"
+)
+set_tests_properties (${prefix}_test_arabic_to_roman_1 PROPERTIES
+    PASS_REGULAR_EXPRESSION "IV"
+    LABELS "${MODULE}"
+)
+
+add_test(
+NAME ${prefix}_test_arabic_to_roman_2
+COMMAND ${APPLICATION} "1000"
+)
+set_tests_properties (${prefix}_test_arabic_to_roman_2 PROPERTIES
+PASS_REGULAR_EXPRESSION "M"
 LABELS "${MODULE}"
 )
 

--- a/modules/chuvashov_a_ra_convertor/CTestTests.txt
+++ b/modules/chuvashov_a_ra_convertor/CTestTests.txt
@@ -1,0 +1,121 @@
+#############################################
+##### Testing
+#############################################
+
+set(prefix "${MODULE}")
+
+add_test(
+    NAME ${prefix}_run
+    COMMAND ${APPLICATION}
+)
+set_tests_properties (${prefix}_run PROPERTIES
+    LABELS "${MODULE}"
+)
+
+add_test(
+    NAME ${prefix}_romanToArabicCheck_one
+    COMMAND ${APPLICATION} "IX"
+)
+set_tests_properties (${prefix}_romanToArabicCheck_one PROPERTIES
+    PASS_REGULAR_EXPRESSION "9"
+    LABELS "${MODULE}"
+)
+
+add_test(
+    NAME ${prefix}_test_help
+    COMMAND ${APPLICATION} --help
+)
+set_tests_properties (${prefix}_test_help PROPERTIES
+    PASS_REGULAR_EXPRESSION "This is an application for converting Roman numerals to Arabic.*"
+    LABELS "${MODULE}"
+)
+
+add_test(
+    NAME ${prefix}_test_err
+    COMMAND ${APPLICATION} "IVX"
+)
+set_tests_properties (${prefix}_test_err PROPERTIES
+    PASS_REGULAR_EXPRESSION "Error: Incorrect input"
+    LABELS "${MODULE}"
+)
+
+add_test(
+    NAME ${prefix}_incorrect_input
+    COMMAND ${APPLICATION} "IVX" "I" "V"
+)
+set_tests_properties (${prefix}_incorrect_input PROPERTIES
+    PASS_REGULAR_EXPRESSION "Error:.*Incorrect input.*"
+    LABELS "${MODULE}"
+)
+
+add_test(
+NAME ${prefix}_test_roman_to_arabic_1
+COMMAND ${APPLICATION} "I"
+)
+set_tests_properties (${prefix}_test_roman_to_arabic_1 PROPERTIES
+PASS_REGULAR_EXPRESSION "1"
+LABELS "${MODULE}"
+)
+
+add_test(
+NAME ${prefix}_test_roman_to_arabic_3
+COMMAND ${APPLICATION} "XVI"
+)
+set_tests_properties (${prefix}_test_roman_to_arabic_3 PROPERTIES
+PASS_REGULAR_EXPRESSION "16"
+LABELS "${MODULE}"
+)
+
+add_test(
+NAME ${prefix}_test_roman_to_arabic_4
+COMMAND ${APPLICATION} "MDCLXVI"
+)
+set_tests_properties (${prefix}_test_roman_to_arabic_4 PROPERTIES
+PASS_REGULAR_EXPRESSION "1666"
+LABELS "${MODULE}"
+)
+
+add_test(
+NAME ${prefix}_test_arabic_to_roman_3
+COMMAND ${APPLICATION} "16"
+)
+set_tests_properties (${prefix}_test_arabic_to_roman_3 PROPERTIES
+PASS_REGULAR_EXPRESSION "XVI"
+LABELS "${MODULE}"
+)
+
+add_test(
+NAME ${prefix}_test_arabic_to_roman_4
+COMMAND ${APPLICATION} "1994"
+)
+set_tests_properties (${prefix}_test_arabic_to_roman_4 PROPERTIES
+PASS_REGULAR_EXPRESSION "MCMXCIV"
+LABELS "${MODULE}"
+)
+
+add_test(
+NAME ${prefix}_test_arabic_to_roman_5
+COMMAND ${APPLICATION} "1666"
+)
+set_tests_properties (${prefix}_test_arabic_to_roman_5 PROPERTIES
+PASS_REGULAR_EXPRESSION "MDCLXVI"
+LABELS "${MODULE}"
+)
+
+add_test(
+NAME ${prefix}_incorrect_input_2
+COMMAND ${APPLICATION} "0"
+)
+set_tests_properties (${prefix}_incorrect_input_2 PROPERTIES
+PASS_REGULAR_EXPRESSION "Error: Input must be greater than 0 and less than 15000"
+LABELS "${MODULE}"
+)
+
+add_test(
+NAME ${prefix}_incorrect_input_3
+COMMAND ${APPLICATION} "15001"
+)
+set_tests_properties (${prefix}_incorrect_input_3 PROPERTIES
+PASS_REGULAR_EXPRESSION "Error: Input must be greater than 0 and less than 15000"
+LABELS "${MODULE}"
+)

--- a/modules/chuvashov_a_ra_convertor/application/CMakeLists.txt
+++ b/modules/chuvashov_a_ra_convertor/application/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(target ${APPLICATION})
+
+file(GLOB srcs "*.cpp")
+set_source_files_properties(${srcs} PROPERTIES
+    LABELS "${MODULE};Application")
+
+add_executable(${target} ${srcs})
+set_target_properties(${target} PROPERTIES
+    OUTPUT_NAME ${MODULE}
+    LABELS "${MODULE};Application")
+
+target_link_libraries(${target} ${LIBRARY})
+if (UNIX)
+  target_link_libraries(${target} ${CMAKE_THREAD_LIBS_INIT})
+endif (UNIX)

--- a/modules/chuvashov_a_ra_convertor/application/application.cpp
+++ b/modules/chuvashov_a_ra_convertor/application/application.cpp
@@ -1,0 +1,13 @@
+// Copyright 2024 Moiseev Nikita
+
+#include <iostream>
+
+#include "include/ra_convertor_app.h"
+
+int main(int argc, char* argv[]) {
+  auto output = ConverterApplication()(argc, argv);
+
+  std::cout << output << '\n';
+
+  return 0;
+}

--- a/modules/chuvashov_a_ra_convertor/include/ra_convertor_app.h
+++ b/modules/chuvashov_a_ra_convertor/include/ra_convertor_app.h
@@ -1,0 +1,22 @@
+// Copyright 2024 Moiseev Nikita
+#pragma once
+
+#include <cmath>
+#include <stdexcept>
+#include <vector>
+#include <utility>
+#include <algorithm>
+#include <string>
+
+#include "include/ra_convertor.h"
+
+class ConverterApplication {
+public:
+	ConverterApplication() = default;
+	std::string operator()(int argc, char* argv[]);
+
+private:
+	std::string hullMessage{};
+	bool validate(int argc, char* argv[]);
+	void help(const char* appName, const char* msg = nullptr);
+};

--- a/modules/chuvashov_a_ra_convertor/include/ra_convertor_app.h
+++ b/modules/chuvashov_a_ra_convertor/include/ra_convertor_app.h
@@ -11,12 +11,11 @@
 #include "include/ra_convertor.h"
 
 class ConverterApplication {
-public:
-	ConverterApplication() = default;
-	std::string operator()(int argc, char* argv[]);
-
-private:
-	std::string hullMessage{};
-	bool validate(int argc, char* argv[]);
-	void help(const char* appName, const char* msg = nullptr);
+ public:
+    ConverterApplication() = default;
+    std::string operator()(int argc, char* argv[]);
+ private:
+    std::string hullMessage{};
+    bool validate(int argc, char* argv[]);
+    void help(const char* appName, const char* msg = nullptr);
 };

--- a/modules/chuvashov_a_ra_convertor/src/ra_convertor_app.cpp
+++ b/modules/chuvashov_a_ra_convertor/src/ra_convertor_app.cpp
@@ -38,8 +38,8 @@ void ConverterApplication::help(const char* appName, const char* msg) {
 
     if (msg) message << "Error: " << msg << '\n';
 
-    message << "This is an application for converting Roman numerals
-        to Arabic and vice versa\n";
+    message << "This is an application for converting Roman numerals "
+        << "to Arabic and vice versa\n";
     message << "Please provide a single Roman or Arabic numeral argument.\n\n";
     message << "Example usage:\n";
     message << " $ " << appName << " IX\n";

--- a/modules/chuvashov_a_ra_convertor/src/ra_convertor_app.cpp
+++ b/modules/chuvashov_a_ra_convertor/src/ra_convertor_app.cpp
@@ -33,7 +33,6 @@ bool ConverterApplication::validate(int argc, char* argv[]) {
     return true;
 }
 
-
 void ConverterApplication::help(const char* appName, const char* msg) {
     std::stringstream message;
 

--- a/modules/chuvashov_a_ra_convertor/src/ra_convertor_app.cpp
+++ b/modules/chuvashov_a_ra_convertor/src/ra_convertor_app.cpp
@@ -1,0 +1,66 @@
+// Copyright 2024 Moiseev Nikita
+
+#include "include/ra_convertor_app.h"
+
+#include <cstring>
+#include <sstream>
+
+bool ConverterApplication::validate(int argc, char* argv[]) {
+    if (argc < 2) {
+        help(argv[0]);
+        return false;
+    }
+    if (std::strcmp(argv[1], "--help") == 0) {
+        help(argv[0]);
+        return false;
+    }
+    std::string input(argv[1]);
+    Convertor convertor;
+    try {
+        int arabic_num = std::stoi(input);
+        if (arabic_num < 1 || arabic_num > 15000) {
+            help(argv[0], "Input must be greater than 0 and less than 15000");
+            return false;
+        }
+    }
+    catch (const std::invalid_argument&) {
+        if (!convertor.isRomanValid(input)) {
+            help(argv[0], "Incorrect input");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+
+void ConverterApplication::help(const char* appName, const char* msg) {
+    std::stringstream message;
+
+    if (msg) message << "Error: " << msg << '\n';
+
+    message << "This is an application for converting Roman numerals to Arabic and vice versa\n";
+    message << "Please provide a single Roman or Arabic numeral argument.\n\n";
+    message << "Example usage:\n";
+    message << " $ " << appName << " IX\n";
+    message << " $ " << appName << " 9\n";
+
+    hullMessage = message.str();
+}
+
+std::string ConverterApplication::operator()(int argc, char* argv[]) {
+    if (validate(argc, argv)) {
+        std::string input(argv[1]);
+        Convertor convertor;
+
+        try {
+            int arabic_num = std::stoi(input);
+            hullMessage = convertor.ArabicToRoman(arabic_num);
+        }
+        catch (const std::invalid_argument&) {
+            int arabic_num = convertor.RomanToArabic(input);
+            hullMessage = std::to_string(arabic_num);
+        }
+    }
+    return hullMessage;
+}

--- a/modules/chuvashov_a_ra_convertor/src/ra_convertor_app.cpp
+++ b/modules/chuvashov_a_ra_convertor/src/ra_convertor_app.cpp
@@ -38,7 +38,8 @@ void ConverterApplication::help(const char* appName, const char* msg) {
 
     if (msg) message << "Error: " << msg << '\n';
 
-    message << "This is an application for converting Roman numerals to Arabic and vice versa\n";
+    message << "This is an application for converting Roman numerals
+        to Arabic and vice versa\n";
     message << "Please provide a single Roman or Arabic numeral argument.\n\n";
     message << "Example usage:\n";
     message << " $ " << appName << " IX\n";


### PR DESCRIPTION
Было реализовано консольное приложение для работы с конвертером римских чисел в арабские и наоборот.
Всю необходимую информацию можно узнать, запустив приложение с флагом --help.
```
This is an application for converting Roman numerals to Arabic and vice versa
 Please provide a single Roman or Arabic numeral argument.
 Example usage 
 IX
 9 
```
